### PR TITLE
マイページ住所登録・編集ボタンを条件分岐で変更

### DIFF
--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -13,11 +13,11 @@ class AddressesController < ApplicationController
   end
 
   def edit
-    @address = Address.find_by(user_id: params[:id])
+    @address = Address.find_by(user_id: current_user.id)
   end
 
   def update
-    @address = Address.find(params[:id])
+    @address = Address.find_by(user_id: current_user.id)
     if @address.update(address_params)
       redirect_to user_path(current_user.id), notice: '住所登録を更新しました'
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   
   def show
+    @address = Address.find_by(user_id: current_user.id)
   end
   
   def edit

--- a/app/views/shared/_leftBar.html.haml
+++ b/app/views/shared/_leftBar.html.haml
@@ -25,7 +25,6 @@
     プロフィール
     .side-menu__content--arrow
       = icon('fas', 'chevron-right')
-  // 以下、サーバ実装後の情報の登録の有無確認用
   - if @address.blank?
     = link_to new_address_path, class: 'side-menu__content' do
       発送元・お届け先住所の登録

--- a/app/views/shared/_leftBar.html.haml
+++ b/app/views/shared/_leftBar.html.haml
@@ -26,16 +26,16 @@
     .side-menu__content--arrow
       = icon('fas', 'chevron-right')
   // 以下、サーバ実装後の情報の登録の有無確認用
-  //- if Address.find_by(user_id: params[:format]) == nil
-  = link_to new_address_path, class: 'side-menu__content' do
-    発送元・お届け先住所の登録
-    .side-menu__content--arrow
-      = icon('fas', 'chevron-right')
-  //- else
-  = link_to '#', class: 'side-menu__content' do
-    発送元・お届け先住所の変更
-    .side-menu__content--arrow
-      = icon('fas', 'chevron-right')
+  - if @address.blank?
+    = link_to new_address_path, class: 'side-menu__content' do
+      発送元・お届け先住所の登録
+      .side-menu__content--arrow
+        = icon('fas', 'chevron-right')
+  - else
+    = link_to edit_address_path, class: 'side-menu__content' do
+      発送元・お届け先住所の変更
+      .side-menu__content--arrow
+        = icon('fas', 'chevron-right')
 
   = link_to '#', class: 'side-menu__content' do
     支払い方法

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,12 +1,13 @@
 Rails.application.routes.draw do
   devise_for :users
   root "items#home"
-  resources :users, only: [:edit, :update, :show]
-  collection do
-    get 'exhibitionList', to: 'users#exhibitionList'
-    get 'soldList', to: 'users#soldList'
-    get 'contact', to: 'users#contact'
-    get 'info', to: 'users#info'
+  resources :users, only: [:edit, :update, :show] do
+    collection do
+      get 'exhibitionList', to: 'users#exhibitionList'
+      get 'soldList', to: 'users#soldList'
+      get 'contact', to: 'users#contact'
+      get 'info', to: 'users#info'
+    end
   end
   resources :items, only: [:new, :create, :show, :edit] do
     collection do


### PR DESCRIPTION
# What
住所を登録していないユーザーの場合はマイページに住所の新規登録ボタン。
登録しているユーザーには編集ボタンを表示するように条件分岐を実装しました。

# Why
表示するメニューをユーザーの状態に応じて変更することによって、ユーザーへの誤解を産みづらくする為。