### PR TITLE
商品詳細の画像表示位置を修正

### DIFF
--- a/app/assets/stylesheets/show.scss
+++ b/app/assets/stylesheets/show.scss
@@ -11,23 +11,26 @@
       text-align: center;
       font-weight: bold;
       font-size: 24px;
+      padding-top: 20px;
     }
     &__images {
       height: 320px;
-      width: 100%;
-      margin: 16px 0 0;
+      min-width:320px;
+      margin:0 auto;
       position: relative;
       &--scroll-image{
         height: 320px;
-        width: 100%;
         display: flex;
         overflow-x: scroll;
         padding-left: 10px;
         .image-box{
           flex-basis: 0 0 320px;
           padding: 10px;
-          height: 320px;
-          min-width: 320px;
+          min-height: 280px;
+          min-width: 280px;
+          max-width:320px;
+          max-height:320px;
+          margin:0 auto;
           position: relative;
           img{
             position: absolute;


### PR DESCRIPTION
# What
・主に「.image-box{}」に「margin:0 auto;」を追加

# Why
・商品詳細の表示画像が3枚以下の際に左端に寄ってしまう不自然な状態だったため、常に中央に表示されるように修正