### PR TITLE
商品購入確認画面の住所登録時・未登録時のビューの変更

### DIFF
--- a/app/views/addresses/new.html.haml
+++ b/app/views/addresses/new.html.haml
@@ -3,7 +3,7 @@
   .form-body
     .container
       .container__title
-        発送元・お届け先住所変更
+        発送元・お届け先住所登録
       .container__body
         .body__form
           = form_with model: @address, url: addresses_path, local: true, method: :post do |f|

--- a/app/views/items/purchase.html.haml
+++ b/app/views/items/purchase.html.haml
@@ -37,23 +37,30 @@
               - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
               = exp_month + " / " + exp_year
       .shipping-address
-        .confirmation-box
-          .confirmation-box__heading
-            配送先
-          .confirmation-box__detail
-            〒
-            = @address.postal_code
-            %br/
-            = @address.prefecture
-            = @address.city
-            = @address.house_num
-            = @address.detail
-            -# 東京都 渋谷区 神南1丁目12-16 アジアビル８F
-            %br/
-            = @address.firstname
-            = @address.lastname
-        =link_to edit_address_path(current_user), class: 'shipping-address__changing-btn' do
-          変更する
+        .confirmation-box{ style: "width: 100%;"}
+          - if @address.blank?
+            .address-btn-master{style: "display: flex; justify-content: space-between;"}
+              .confirmation-box__heading
+                配送先
+              =link_to new_address_path(current_user), class: 'shipping-address__changing-btn' do
+                登録する
+          - else
+            .address-btn-master{style: "display: flex; justify-content: space-between;"}
+              .confirmation-box__heading
+                配送先
+              =link_to edit_address_path(current_user), class: 'shipping-address__changing-btn' do
+                変更する
+            .confirmation-box__detail
+              〒
+              = @address.postal_code
+              %br/
+              = @address.prefecture
+              = @address.city
+              = @address.house_num
+              = @address.detail
+              %br/
+              = @address.firstname
+              = @address.lastname
       .purchase-btn
         = form_tag(action: :pay, method: :post) do
           %button.submit-btn{ style: "margin-top: 0; width: 100%;"} 購入する


### PR DESCRIPTION
# What
商品購入確認画面の住所登録時・未登録時のビューの変更をしました

# Why
購入確認画面での住所の表示を変える事によってユーザーに混乱を与えないため