### PR TITLE
トップページで全親カテゴリーの新着商品表示

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,7 +9,7 @@ class ItemsController < ApplicationController
     @roots_cat = []
     @items = []
     roots = Category.where(ancestry: nil)
-    3.times do |count|
+    10.times do |count|
       @roots_cat.push(roots[count]) # TODO:ランダム
       @items.push(Item.where(bought_user_id: nil).where(category_id: @roots_cat[count].indirect_ids).order(created_at: "DESC").take(10))
     end

--- a/app/views/items/home.html.haml
+++ b/app/views/items/home.html.haml
@@ -62,11 +62,11 @@
         %p.item__detail お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
 
   .pickup-container
-    %h2.head ピックアップカテゴリー
+    %h2.head カテゴリー一覧
     .product-box
       .product-head
         = link_to "#",class: "link" do
-          %h3.title 新規投稿商品
+          %h3.title 新着商品
   =render 'shared/items-index'
 
 .app-banner


### PR DESCRIPTION
# What
トップページにて各カテゴリーごとに新着１０件までを表示

# Why
新着アイテムへのアクセスをトップページを表示することで商品の流動性に寄与することができる。出品から取引完了までのサイクルを短くできるため、出品しやすくなる。
また、商品の最新情報を簡単に手に入れられるようになる。