### PR TITLE
マイページのカーソルの調整&戻るボタンの実装

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -75,7 +75,10 @@
               = @item.schedule.name
 
         .body__purchase-btn
-          - if user_signed_in? && current_user.id == @item.user_id
+          - if user_signed_in? && @item.bought_user_id
+            =link_to user_path do
+              %button.back-btn 戻る
+          - elsif user_signed_in? && current_user.id == @item.user_id
             =link_to edit_item_path do
               %button.submit-btn{ style: "width: 100%; font-size: 14px;"} 編集する
             =link_to item_path, method: :delete, data: {confirm: "本当に削除しますか?"} do

--- a/app/views/users/exhibitionList.html.haml
+++ b/app/views/users/exhibitionList.html.haml
@@ -16,8 +16,8 @@
           - if @selling_items.present?
             - @selling_items.each do |item|
               %ul
-                %li
-                  =link_to item_path(item) do
+                =link_to item_path(item) do
+                  %li
                     .image-box
                       = image_tag item.images[0].image.url
                     .text

--- a/app/views/users/soldList.html.haml
+++ b/app/views/users/soldList.html.haml
@@ -15,8 +15,8 @@
           - if @sold_items.present?
             - @sold_items.each do |item|
               %ul
-                %li
-                  =link_to item_path(item) do
+                =link_to item_path(item) do
+                  %li
                     .image-box
                       = image_tag item.images[0].image.url
                     .text


### PR DESCRIPTION
## what
①マイページのそれぞれのアイテム一覧にて押下範囲を広げる。
②購入済み・売却済み商品は、戻るボタンのみ表示するようにする。

## why
①選択操作の操作性向上
②売却済みアイテムにおいて、購入等の操作をできなくする為